### PR TITLE
Support arrow functions and destructuring

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,10 @@ var buble = require('./buble')
 var options = {
   target: { chrome: 52 },
   transforms: {
+    arrow: true,
     computedProperty: true,
     conciseMethodProperty: true,
+    destructuring: true,
     templateString: true
   }
 }


### PR DESCRIPTION
I knocked my head against a wall for a while until I realised that maybe Babel wasn't involved in the template's embedded JS. I'm not sure whether there are any good arguments against adding these two?
