### PR TITLE
fix object destructuring with custom variable name

### DIFF
--- a/buble.js
+++ b/buble.js
@@ -7025,6 +7025,8 @@ var Identifier$1 = (function (Node$$1) {
 			!(this.parent.type === 'MemberExpression' && this.parent.property === this && !this.parent.computed) &&
 			// not in an Array destructure pattern
 			!(this.parent.type === 'ArrayPattern') &&
+			// not in an Object destructure pattern
+			!(this.parent.parent.type === 'ObjectPattern') &&
 			// skip globals + commonly used shorthands
 			!hash[this.name] &&
 			// not already in scope


### PR DESCRIPTION
When doing object destructuring with a custom variable name (`{ obj_prop: var_name }`), we get an error: The generated code contains `var _vm.var_name = ref.obj_prop` which is invalid syntax. So we need to skip overwriting to add a `_vm.` to the variable name.

Fixes #6